### PR TITLE
Add ability to load only subscribed folders in Mailbox.

### DIFF
--- a/src/Protocol/Imap.php
+++ b/src/Protocol/Imap.php
@@ -628,19 +628,21 @@ class Imap
      *
      * @param  string $reference mailbox reference for list
      * @param  string $mailbox   mailbox name match with wildcards
+     * @param  bool $subscribedOnly get only subscribed folders or all folders
      * @return array mailboxes that matched $mailbox as array(globalName => array('delim' => .., 'flags' => ..))
      * @throws \Zend\Mail\Protocol\Exception\ExceptionInterface
      */
-    public function listMailbox($reference = '', $mailbox = '*')
+    public function listMailbox($reference = '', $mailbox = '*', $subscribedOnly = false)
     {
+        $command = $subscribedOnly ? 'LSUB' : 'LIST';
         $result = [];
-        $list = $this->requestAndResponse('LIST', $this->escapeString($reference, $mailbox));
+        $list = $this->requestAndResponse($command, $this->escapeString($reference, $mailbox));
         if (! $list || $list === true) {
             return $result;
         }
 
         foreach ($list as $item) {
-            if (count($item) != 4 || $item[0] != 'LIST') {
+            if (count($item) != 4 || $item[0] != $command) {
                 continue;
             }
             $result[$item[3]] = ['delim' => $item[2], 'flags' => $item[1]];

--- a/src/Storage/Imap.php
+++ b/src/Storage/Imap.php
@@ -319,14 +319,15 @@ class Imap extends AbstractStorage implements Folder\FolderInterface, Writable\W
      * get root folder or given folder
      *
      * @param  string $rootFolder get folder structure for given folder, else root
+     * @param  bool $subscribedOnly get only subscribed folders or all folders
      * @throws Exception\RuntimeException
      * @throws Exception\InvalidArgumentException
      * @throws Protocol\Exception\RuntimeException
      * @return Folder root or wanted folder
      */
-    public function getFolders($rootFolder = null)
+    public function getFolders($rootFolder = null, $subscribedOnly = false)
     {
-        $folders = $this->protocol->listMailbox((string) $rootFolder);
+        $folders = $this->protocol->listMailbox((string) $rootFolder, '*', $subscribedOnly);
         if (! $folders) {
             throw new Exception\InvalidArgumentException('folder not found');
         }


### PR DESCRIPTION
Add ability to load only subscribed folders in Mailbox. Default value - load all folders.
This is needed for correct works with folders like "Calendar/United States holidays" which available to sync, but can not be synced correctly.