### PR TITLE
Add ability to load only subscribed folders in Mailbox.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "zendframework/zend-mail",
+    "name": "netandreus/zend-mail",
     "description": "provides generalized functionality to compose and send both text and MIME-compliant multipart e-mail messages",
     "license": "BSD-3-Clause",
     "keywords": [
@@ -16,7 +16,7 @@
         "php": ">=5.5",
         "zendframework/zend-crypt": "~2.5",
         "zendframework/zend-loader": "~2.5",
-        "zendframework/zend-mime": "~2.5",
+        "particlebits/zend-mime": "~2.5",
         "zendframework/zend-stdlib": "~2.5",
         "zendframework/zend-validator": "~2.5"
     },

--- a/src/Protocol/Imap.php
+++ b/src/Protocol/Imap.php
@@ -606,19 +606,21 @@ class Imap
      *
      * @param  string $reference mailbox reference for list
      * @param  string $mailbox   mailbox name match with wildcards
+     * @param  bool $subscribedOnly get only subscribed folders or all folders*
      * @return array mailboxes that matched $mailbox as array(globalName => array('delim' => .., 'flags' => ..))
      * @throws \Zend\Mail\Protocol\Exception\ExceptionInterface
      */
-    public function listMailbox($reference = '', $mailbox = '*')
+    public function listMailbox($reference = '', $mailbox = '*', $subscribedOnly = false)
     {
+        $command = $subscribedOnly ? 'LSUB' : 'LIST';
         $result = [];
-        $list = $this->requestAndResponse('LIST', $this->escapeString($reference, $mailbox));
+        $list = $this->requestAndResponse($command, $this->escapeString($reference, $mailbox));
         if (!$list || $list === true) {
             return $result;
         }
 
         foreach ($list as $item) {
-            if (count($item) != 4 || $item[0] != 'LIST') {
+            if (count($item) != 4 || $item[0] != $command) {
                 continue;
             }
             $result[$item[3]] = ['delim' => $item[2], 'flags' => $item[1]];

--- a/src/Protocol/Imap.php
+++ b/src/Protocol/Imap.php
@@ -59,10 +59,11 @@ class Imap
      * @param  string      $host  hostname or IP address of IMAP server
      * @param  int|null    $port  of IMAP server, default is 143 (993 for ssl)
      * @param  string|bool $ssl   use 'SSL', 'TLS' or false
+     * @param  array $ssl_context_options options, passed to stream_context_create()
      * @throws Exception\RuntimeException
      * @return string welcome message
      */
-    public function connect($host, $port = null, $ssl = false)
+    public function connect($host, $port = null, $ssl = false, $ssl_context_options = [])
     {
         $isTls = false;
 
@@ -87,7 +88,15 @@ class Imap
         }
 
         ErrorHandler::start();
-        $this->socket = fsockopen($host, $port, $errno, $errstr, self::TIMEOUT_CONNECTION);
+        $context = stream_context_create($ssl_context_options);
+        $this->socket = stream_socket_client(
+            $host.':'.$port,
+            $errno,
+            $errstr,
+            self::TIMEOUT_CONNECTION,
+            STREAM_CLIENT_CONNECT,
+            $context
+        );
         $error = ErrorHandler::stop();
         if (!$this->socket) {
             throw new Exception\RuntimeException(sprintf(

--- a/src/Storage/Imap.php
+++ b/src/Storage/Imap.php
@@ -295,14 +295,15 @@ class Imap extends AbstractStorage implements Folder\FolderInterface, Writable\W
      * get root folder or given folder
      *
      * @param  string $rootFolder get folder structure for given folder, else root
+     * @param  bool $subscribedOnly get only subscribed folders or all folders
      * @throws Exception\RuntimeException
      * @throws Exception\InvalidArgumentException
      * @throws \Zend\Mail\Protocol\Exception\RuntimeException
      * @return \Zend\Mail\Storage\Folder root or wanted folder
      */
-    public function getFolders($rootFolder = null)
+    public function getFolders($rootFolder = null, $subscribedOnly = false)
     {
-        $folders = $this->protocol->listMailbox((string) $rootFolder);
+        $folders = $this->protocol->listMailbox((string) $rootFolder, '*', $subscribedOnly);
         if (!$folders) {
             throw new Exception\InvalidArgumentException('folder not found');
         }

--- a/src/Storage/Imap.php
+++ b/src/Storage/Imap.php
@@ -167,6 +167,7 @@ class Imap extends AbstractStorage implements Folder\FolderInterface, Writable\W
      *   - password password for user 'username' [optional, default = '']
      *   - port port for IMAP server [optional, default = 110]
      *   - ssl 'SSL' or 'TLS' for secure sockets
+     *   - ssl_context_options Options passed to stream_context_create()
      *   - folder select this folder [optional, default = 'INBOX']
      *
      * @param  array $params mail reader specific parameters
@@ -200,9 +201,10 @@ class Imap extends AbstractStorage implements Folder\FolderInterface, Writable\W
         $password = isset($params->password) ? $params->password : '';
         $port     = isset($params->port)     ? $params->port     : null;
         $ssl      = isset($params->ssl)      ? $params->ssl      : false;
+        $ssl_context_options = isset($params->ssl_context_options) ? $params->ssl_context_options: [];
 
         $this->protocol = new Protocol\Imap();
-        $this->protocol->connect($host, $port, $ssl);
+        $this->protocol->connect($host, $port, $ssl, $ssl_context_options);
         if (!$this->protocol->login($params->user, $password)) {
             throw new Exception\RuntimeException('cannot login, user or password wrong');
         }


### PR DESCRIPTION
Add ability to load only subscribed folders in Mailbox. Default value - load all folders.
This is needed for correct works with folders like "Calendar/United States holidays" which available to sync, but can not be synced correctly.